### PR TITLE
Only composer require missing packages #4

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -37,18 +37,18 @@ drupal8ci_install() {
 		guzzlehttp/guzzle:^6.0@dev
 	)
 	# Find out what packages are already required.
-	installed_deps=`composer show -ND`
+	existing_packages=`composer show -ND`
 	# Determine which of these dependencies are not already installed by using
 	# uniq -u. We don't want to re-install existing dependencies as require-dev.
-	# We also don't want any of the items in $installed_deps to show up here, so
+	# We also don't want any of the items in $existing_packages to show up here so
 	# we echo those packages twice to ensure they don't. In other words, the only
 	# packages that would end up in $dev_deps are just ones that only occur once.
-	dev_deps=`echo "${all_dev_deps[@]%:*} $installed_deps $installed_deps" |
+	dev_deps=`echo "${all_dev_deps[@]%:*} $existing_packages $existing_packages" |
 		tr ' ' '\n' |
 		sort |
 		uniq -u`
 
-	# Only run composer install if we found some dependencies to add.
+	# Only run composer install if we found some packages to install.
 	if [[ -n $dev_deps ]]; then
 		# Now find the dev dependencies with versions above from the $all_dev_deps
 		# array. We do this by printing out the array as multiline, and passing it


### PR DESCRIPTION
This wasn't trivial to solve. I'd welcome simpler solutions to the problem. But it does seem to fix it with a fresh checkout of _drupal-project_.

```
$ composer create-project drupal-composer/drupal-project:8.x-dev drupal-project --stability dev --no-interaction
$ cd drupal-project
$ git init && git add . && git commit -m "Initial commit of fresh drupal-project."
$ curl -L https://raw.githubusercontent.com/q0rban/drupal8ci/1c9992f1258934e26b6b379e053813c0a98300fc/setup.sh | bash
$ git diff composer.json
```
```diff
diff --git a/composer.json b/composer.json
index f36e2a6..72bfd8f 100644
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,13 @@
     },
     "require-dev": {
         "behat/mink": "~1.7",
+        "behat/mink-extension": "v2.2",
         "behat/mink-goutte-driver": "~1.2",
+        "behat/mink-selenium2-driver": "^1.3",
+        "bex/behat-screenshot": "^1.2",
+        "drupal/coder": "^8.2",
+        "drupal/drupal-extension": "master-dev",
+        "guzzlehttp/guzzle": "^6.0@dev",
         "jcalderonzumba/gastonjs": "~1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
         "mikey179/vfsstream": "~1.2",
```