### PR TITLE
Simplify dev dependencies

### DIFF
--- a/dist/.circleci/config.yml
+++ b/dist/.circleci/config.yml
@@ -67,6 +67,9 @@ behat_tests: &behat_tests
           robo install:dependencies
           robo setup:drupal || true
           cd web
+          # For a quick start, set the following environment variable to a URL that contains
+          # a database dump. Alternativelly, give CircleCI access to your development environment
+          # and use Drush site aliases to run `drush sql-sync`.
           wget -O dump.sql $DB_DUMP_URL
           ../vendor/bin/drush sql-cli < dump.sql
           ../vendor/bin/drush updatedb -y -v

--- a/setup.sh
+++ b/setup.sh
@@ -26,14 +26,11 @@ drupal8ci_install() {
 	#
 	# behat/mink-extension is pinned until https://github.com/Behat/MinkExtension/pull/311 gets fixed.
 	composer require --dev \
-		cweagans/composer-patches \
 		behat/mink-extension:v2.2 \
 		behat/mink-selenium2-driver:^1.3 \
 		bex/behat-screenshot \
 		drupal/coder:^8.2 \
-		drupal/drupal-extension:master-dev \
-		drush/drush:~8.1 \
-		guzzlehttp/guzzle:^6.0@dev
+		drupal/drupal-extension:master-dev
 }
 
 #######################################


### PR DESCRIPTION
Some non-dev dependencies are already part of drupal-project so
we don't need to require them.